### PR TITLE
Problème lors de la création d'un nouveau projet pour les JDK > 8

### DIFF
--- a/ticket/pom.xml
+++ b/ticket/pom.xml
@@ -179,6 +179,32 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!-- JAXB -->
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>2.3.0.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>2.3.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/ticket/ticket-business/pom.xml
+++ b/ticket/ticket-business/pom.xml
@@ -46,6 +46,26 @@
             <artifactId>bval-jsr</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
+
 
         <!-- ===== Tests ===== -->
         <dependency>


### PR DESCRIPTION
Sur le chapitre 4 de la 1ère partie, lorsqu'on veut créer un nouveau projet. Si notre projet est lié à une JDK > 8 (11 dans mon cas), Struts nous informe que lors de la création de validateur de contraintes il ne trouve pas les dépendances jaxb relatives à ce dernier (AbstractManager ligne 18).

Ceci est du au fait que les packages jaxb ne sont plus inclus par défaut sur les JDK à partir de la version 9

Il faut donc rajouter ces dépendances afin de ne plus avoir ce problème